### PR TITLE
Corrige actualización de premio al finalizar misión

### DIFF
--- a/script.js
+++ b/script.js
@@ -914,7 +914,9 @@ function mostrarPopupVictoria(total) {
   }
 
   // 3. Actualizar toda la UI de contadores
+  // Refrescar contadores de la sección de misión y del cartel superior
   refrescarProgresosPremios();
+  mostrarCartelProgresoPremio();
   
   const resumenCompleto = document.getElementById("texto-resumen-estrellas");
   if (resumenCompleto) {
@@ -975,7 +977,9 @@ function mostrarPopupVictoria(total) {
       // Limpiar el premio ganado para poder empezar uno nuevo
       const key = tipoMision === "diario" ? "premio-diario" : "premio-semanal";
       localStorage.removeItem(key);
+      // Al remover el premio se debe actualizar toda la visualización de progreso
       refrescarProgresosPremios(); // Refrescar UI de configuración
+      mostrarCartelProgresoPremio();
 
     } else {
       pestañaActual = 0; // Quedarse en la primera página


### PR DESCRIPTION
## Resumen
- Refresca contadores y cartel de progreso al finalizar cada misión.
- Actualiza la visualización al ganar un premio, removiendo el objetivo y mostrando el popup correspondiente.

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_689fd2871cdc83229c700ae39a4c1598